### PR TITLE
Themes: Headers overlay support [4/4]

### DIFF
--- a/config/permissions/org.cyanogenmod.theme.xml
+++ b/config/permissions/org.cyanogenmod.theme.xml
@@ -25,4 +25,7 @@
 
     <!-- Supports themes using v1 of the theme engine -->
     <feature name="org.cyanogenmod.theme.v1" />
+
+    <!-- Supports CMTE extensions -->
+    <feature name="org.cyanogenmod.theme.extensions" />
 </permissions>


### PR DESCRIPTION
Allow themers to replace org.cyanogenmod.theme with
org.cyanogenmod.theme.extensions in theme
manifest features to indicate to  Play Store that their
apk should only show on projects that support extensions.
For example...

A standard CMTE theme has this in the manifest
<uses-feature android:name="org.cyanogenmod.theme" android:required="true"/>

But to show this package in Play Store only to projects
that support extension, use this instead

<uses-feature android:name="org.cyanogenmod.theme.extensions" android:required="true"/>

Change-Id: I6a64f5002fc0a6524a6ff1c54e9b47cd544a6732
